### PR TITLE
BUGFIX: using String(JSON.stringify(object)) instead of String(object)

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ module.exports = {
      * @return  {String} hexColor
      */
     generate: function (object) {
-        return generateColor(JSON.stringify(object));
+        return generateColor(String(JSON.stringify(object)));
     },
     /**
      * Generates hex color from object.
@@ -26,7 +26,7 @@ module.exports = {
      * @return  {String} hexColor
      */
     generate: function (object, seed) {
-        return generateColor(JSON.stringify(object), seed);
+        return generateColor(String(JSON.stringify(object)), seed);
     },
     /**
      * Generates hex color from object.
@@ -37,7 +37,7 @@ module.exports = {
      * @return  {String} hexColor
      */
     generate: function (object, seed, factor) {
-        return generateColor(JSON.stringify(object), seed, factor);
+        return generateColor(String(JSON.stringify(object)), seed, factor);
     }
 };
 

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ module.exports = {
      * @return  {String} hexColor
      */
     generate: function (object) {
-        return generateColor(String(object));
+        return generateColor(JSON.stringify(object));
     },
     /**
      * Generates hex color from object.
@@ -26,7 +26,7 @@ module.exports = {
      * @return  {String} hexColor
      */
     generate: function (object, seed) {
-        return generateColor(String(object), seed);
+        return generateColor(JSON.stringify(object), seed);
     },
     /**
      * Generates hex color from object.
@@ -37,7 +37,7 @@ module.exports = {
      * @return  {String} hexColor
      */
     generate: function (object, seed, factor) {
-        return generateColor(String(object), seed, factor);
+        return generateColor(JSON.stringify(object), seed, factor);
     }
 };
 

--- a/test/generate.js
+++ b/test/generate.js
@@ -62,6 +62,12 @@ describe('generateAny', function () {
         should.exist(hex);
     });
 
+    it('should return a different hex when different objects are provided', function () {
+        var hex = _.generate({ test1: { test1b: 'test_1b' }, test2: 'test2' });
+        var hex2 = _.generate({ test3: { test3b: 'test_3b' }, test4: 'test4' });
+        hex.should.not.be.equal(hex2);
+    });
+
     it('should return same hex when same string provided', function () {
         var hex = _.generate("test");
         var hex2 = _.generate("test");


### PR DESCRIPTION
BUGFIX: using JSON.stringify(object) instead of String(object) because String(object) does always return the String '[object Object]'. So, the color of each object (not null) would be the same. JSON.stringify(object) solves this.