### PR TITLE
Remove Full Lodash require in favor of explicit requires

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 var toHex = require('colornames');
-var _ = require('lodash');
+var words = require('lodash.words');
+var trimStart = require('lodash.trimstart');
+var padEnd = require('lodash.padend');
 var rgbHex = require('rgb-hex');
 var hexRgb = require('hex-rgb');
 
@@ -8,46 +10,49 @@ const TEXT_WEIGHT = 0.25;
 const SEED = 16777215;
 const FACTOR = 49979693;
 
-module.exports = function (object) {
-    return '#' + generateColor(String(JSON.stringify(object)));
+module.exports = function(object) {
+  return '#' + generateColor(String(JSON.stringify(object)));
 };
 
 function getColors(text) {
-    var words = _.words(text);
-    var colors = [];
-    _(words).forEach(function (word) {
-        var color = toHex(word);
-        if (color)
-            colors.push(hexRgb(_.trimStart(color, '#')));
-    });
-    return colors;
+  var words = words(text);
+  var colors = [];
+  words.forEach(function(word) {
+    var color = toHex(word);
+    if (color) colors.push(hexRgb(trimStart(color, '#')));
+  });
+  return colors;
 }
 
 function mixColors(colors) {
-    var mixed = [0, 0, 0];
-    _(colors).forEach(function (value) {
-        for (var i = 0; i < 3; i++) mixed[i] += value[i];
-    });
-    return [mixed[0] / colors.length, mixed[1] / colors.length, mixed[2] / colors.length];
+  var mixed = [0, 0, 0];
+  colors.forEach(function(value) {
+    for (var i = 0; i < 3; i++) mixed[i] += value[i];
+  });
+  return [mixed[0] / colors.length, mixed[1] / colors.length, mixed[2] / colors.length];
 }
 
 function generateColor(text) {
-    var mixed;
-    var colors = getColors(text);
-    if (colors.length > 0) mixed = mixColors(colors);
-    var b = 1;
-    var d = 0;
-    var f = 1;
-    if (text.length > 0) {
-        for (var i = 0; i < text.length; i++)
-            text[i].charCodeAt(0) > d && (d = text[i].charCodeAt(0)), f = parseInt(SEED / d),
-                b = (b + text[i].charCodeAt(0) * f * FACTOR) % SEED;
-    }
-    var hex = (b * text.length % SEED).toString(16);
-    hex = _.padEnd(hex, 6, hex);
-    var rgb = hexRgb(hex);
-    if(mixed)
-        return rgbHex(TEXT_WEIGHT * rgb[0] + MIXED_WEIGHT * mixed[0], TEXT_WEIGHT * rgb[1] + MIXED_WEIGHT * mixed[1],
-            TEXT_WEIGHT * rgb[2] + MIXED_WEIGHT * mixed[2]);
-    return hex;
+  var mixed;
+  var colors = getColors(text);
+  if (colors.length > 0) mixed = mixColors(colors);
+  var b = 1;
+  var d = 0;
+  var f = 1;
+  if (text.length > 0) {
+    for (var i = 0; i < text.length; i++)
+      text[i].charCodeAt(0) > d && (d = text[i].charCodeAt(0)),
+        (f = parseInt(SEED / d)),
+        (b = (b + text[i].charCodeAt(0) * f * FACTOR) % SEED);
+  }
+  var hex = ((b * text.length) % SEED).toString(16);
+  hex = padEnd(hex, 6, hex);
+  var rgb = hexRgb(hex);
+  if (mixed)
+    return rgbHex(
+      TEXT_WEIGHT * rgb[0] + MIXED_WEIGHT * mixed[0],
+      TEXT_WEIGHT * rgb[1] + MIXED_WEIGHT * mixed[1],
+      TEXT_WEIGHT * rgb[2] + MIXED_WEIGHT * mixed[2]
+    );
+  return hex;
 }

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var toHex = require('colornames');
-var words = require('lodash.words');
+var _words = require('lodash.words');
 var trimStart = require('lodash.trimstart');
 var padEnd = require('lodash.padend');
 var rgbHex = require('rgb-hex');
@@ -15,7 +15,7 @@ module.exports = function(object) {
 };
 
 function getColors(text) {
-  var words = words(text);
+  var words = _words(text);
   var colors = [];
   words.forEach(function(word) {
     var color = toHex(word);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "string-to-color",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -164,10 +164,20 @@
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "dev": true
     },
-    "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+    "lodash.padend": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.6.1.tgz",
+      "integrity": "sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4="
+    },
+    "lodash.trimstart": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/lodash.trimstart/-/lodash.trimstart-4.5.1.tgz",
+      "integrity": "sha1-j/TexTLYJIavWVc8OURZFOlEp/E="
+    },
+    "lodash.words": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.words/-/lodash.words-4.2.0.tgz",
+      "integrity": "sha1-Xs/q+Oz4rKqODIOGKV8Zk8nPQDY="
     },
     "minimatch": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
   "dependencies": {
     "colornames": "^1.1.1",
     "hex-rgb": "^1.0.0",
-    "lodash": "^4.17.11",
+    "lodash.padend": "^4.6.1",
+    "lodash.trimstart": "^4.5.1",
+    "lodash.words": "^4.2.0",
     "rgb-hex": "^2.1.0"
   }
 }


### PR DESCRIPTION
Hi, I was going through packages I was using in a frontend environment on [bundlephobia](https://bundlephobia.com/result?p=string-to-color@2.0.1) and saw that `string-to-color` requires the entirety of `lodash` even though it only utilizes 3 of its functions.

This PR removes the reliance on the full `lodash` package and instead replaces it with the 3 individual functions that are being used.

No functionality has changed but this should eliminate ~69kb out of the total size of `string-to-color`.

Also I just noticed that I forgot to disable `prettier` while making the change, sorry for the code-style changes, if that's a deal-breaker for you please let me know and I'm happy to revert those back to your original code style.