### PR TITLE
Fix color suggestion feature by adding the array formatting option wh…

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ function getColors(text) {
   var colors = [];
   words.forEach(function(word) {
     var color = toHex(word);
-    if (color) colors.push(hexRgb(trimStart(color, '#')));
+    if (color) colors.push(hexRgb(trimStart(color, '#'), {format: 'array'}));
   });
   return colors;
 }
@@ -47,7 +47,7 @@ function generateColor(text) {
   }
   var hex = ((b * text.length) % SEED).toString(16);
   hex = padEnd(hex, 6, hex);
-  var rgb = hexRgb(hex);
+  var rgb = hexRgb(hex, {format: 'array'});
   if (mixed)
     return rgbHex(
       TEXT_WEIGHT * rgb[0] + MIXED_WEIGHT * mixed[0],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "string-to-color",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Generates color from any string or any object",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "string-to-color",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Generates color from any string or any object",
   "main": "index.js",
   "scripts": {

--- a/test/generate.js
+++ b/test/generate.js
@@ -17,7 +17,7 @@ describe('generate', function () {
 
     it('should return more reddish color', function () {
         var hex = generate("i am a red fox");
-        var rgb = hexRgb(hex);
+        var rgb = hexRgb(hex, {format: 'array'});
         rgb[0].should.be.above(rgb[1]);
         rgb[0].should.be.above(rgb[2]);
     });


### PR DESCRIPTION
This PR addresses https://github.com/Gustu/string-to-color/issues/12, which reported the color suggestion feature is broken in version 2.2.1.

The change in this PR is small.  One of string-to-color's dependencies, rgb-hex, was recently updated from 1.0 to 4.1. The API has changed.  Instead of returning an RGB array `[0, 0, 0]`, it returns an object `{ red: 0, green: 0, blue: 0 }`.  4.1 can be configured to return an array by passing a second argument, `{ format: 'array' }`.  Adding this options argument fixes the issue, and color suggestion and mixing works again as expected.

See the updated hex-rgb docs here:
https://github.com/sindresorhus/hex-rgb/tree/v4.1.0